### PR TITLE
Fix: Update Neo4j label and clarify search/indexing

### DIFF
--- a/backend/app/services/graphiti_service.py
+++ b/backend/app/services/graphiti_service.py
@@ -259,7 +259,7 @@ class GraphitiService:
                 edge_count = edge_result.single()["edge_count"]
                 
                 # 获取Episode节点数量
-                episode_result = session.run("MATCH (n:Episode) RETURN count(n) as episode_count")
+                episode_result = session.run("MATCH (n:Episodic) RETURN count(n) as episode_count")
                 episode_count = episode_result.single()["episode_count"]
             
             driver.close()


### PR DESCRIPTION
- Changed label from :Episode to :Episodic in get_graph_stats query.
- Noted that search_knowledge relies on Graphiti lib for queries and does not directly use potentially non-existent properties.
- Provided recommendations for verifying and configuring Neo4j full-text search indexes, as this is managed outside graphiti_service.py.