### PR TITLE
Refactor: Use lifespan manager and add dynamic port selection

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -20,6 +20,7 @@ class Settings(BaseSettings):
     # 服务器配置
     HOST: str = Field(default="0.0.0.0", env="HOST")
     PORT: int = Field(default=8000, env="PORT")
+    RETRY_PORTS: list[int] = Field(default_factory=lambda: [8001, 8002, 8003], env="RETRY_PORTS")
     
     # 安全配置
     SECRET_KEY: str = Field(env="SECRET_KEY")


### PR DESCRIPTION
- Replaced deprecated `on_event` with `lifespan` context manager for FastAPI startup and shutdown events.
- Implemented port availability check for the default port (8000).
- Added automatic switching to alternative ports (8001-8003 by default, configurable) if the default port is occupied.
- Improved logging for port selection and application lifecycle events.
- Ensured the application exits gracefully if no suitable port is found.