### PR TITLE
feat: Implement Docker-based deployment solution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,4 +120,14 @@ celerybeat.pid
 # mypy
 .mypy_cache/
 .dmypy.json
-dmypy.json 
+dmypy.json
+
+# Docker .env files
+backend/.env.backend
+neo4j/.env.neo4j
+
+# Neo4j local data/logs (if not using named volumes exclusively)
+# These are typically handled by Docker named volumes in docker-compose.yml,
+# but good to have if someone runs neo4j locally or maps differently.
+neo4j/data/
+neo4j/logs/

--- a/backend/.env.backend.example
+++ b/backend/.env.backend.example
@@ -1,0 +1,19 @@
+# Backend Configuration
+
+# Neo4j connection details
+# These should match the credentials used by the Neo4j service
+NEO4J_URI=bolt://neo4j:7687
+NEO4J_USER=neo4j
+NEO4J_PASSWORD=your_strong_neo4j_password # Please change this
+
+# DeepSeek API Configuration
+DEEPSEEK_API_KEY=your_actual_deepseek_api_key # Please change this
+DEEPSEEK_API_URL=https://api.deepseek.com # Or your specific API endpoint
+
+# FastAPI/Uvicorn settings (optional, defaults are usually fine)
+# HOST=0.0.0.0
+# PORT=8000
+# LOG_LEVEL=info
+
+# Any other backend-specific environment variables can be added here
+# EXAMPLE_SETTING=example_value

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,32 @@
+# Use an official Python runtime as a parent image
+FROM python:3.9-slim
+
+# Set environment variables
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Install system dependencies
+# Add any other system dependencies that your application might need
+# RUN apt-get update && apt-get install -y --no-install-recommends gcc
+
+# Copy the requirements file into the container
+COPY requirements.txt .
+
+# Install Python dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the rest of the application code into the container
+COPY ./app /app/app
+
+# Make port 8000 available to the world outside this container
+EXPOSE 8000
+
+# Define environment variable for the application module
+ENV MODULE_NAME="app.main"
+ENV VARIABLE_NAME="app"
+
+# Command to run the application
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/bridge-knowledge-platform/frontend/Dockerfile
+++ b/bridge-knowledge-platform/frontend/Dockerfile
@@ -1,0 +1,32 @@
+# Stage 1: Build the SvelteKit application
+FROM node:18-alpine AS builder
+
+WORKDIR /app
+
+# Copy package.json and package-lock.json (or yarn.lock if you use yarn)
+COPY package.json package-lock.json* ./
+
+# Install dependencies
+RUN npm install
+
+# Copy the rest of the application source code
+COPY . .
+
+# Build the application
+# Ensure your package.json has a "build" script
+RUN npm run build
+
+# Stage 2: Serve the built application using a lightweight server (e.g., Nginx)
+FROM nginx:stable-alpine
+
+# Copy the built static files from the builder stage
+COPY --from=builder /app/build /usr/share/nginx/html
+
+# Copy the custom Nginx configuration
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+# Expose port 80 for Nginx
+EXPOSE 80
+
+# Start Nginx
+CMD ["nginx", "-g", "daemon off;"]

--- a/bridge-knowledge-platform/frontend/nginx.conf
+++ b/bridge-knowledge-platform/frontend/nginx.conf
@@ -1,0 +1,17 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    root /usr/share/nginx/html;
+    index index.html index.htm;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Optional: Add specific headers or other configurations
+    # location ~* \.(?:css|js)$ {
+    #   expires 1y;
+    #   add_header Cache-Control "public";
+    # }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,73 @@
+version: '3.8'
+
+services:
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./backend/app:/app/app # Optional: for development to reflect code changes
+    env_file:
+      - ./backend/.env.backend
+    depends_on:
+      neo4j:
+        condition: service_healthy
+    networks:
+      - app-network
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8000/health || exit 1"] # Assuming /health endpoint
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+  frontend:
+    build:
+      context: ./bridge-knowledge-platform/frontend
+      dockerfile: Dockerfile
+    ports:
+      - "80:80" # Or 5173:80 if you want to map to a common dev port locally
+    depends_on:
+      - backend
+    networks:
+      - app-network
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost || exit 1"] # Nginx serves on port 80
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+
+  neo4j:
+    image: neo4j:5
+    ports:
+      - "7474:7474" # Neo4j Browser
+      - "7687:7687" # Bolt port
+    volumes:
+      - neo4j_data:/data
+      - neo4j_logs:/logs
+      # If you have plugins, uncomment and adjust the path:
+      # - ./neo4j/plugins:/plugins
+    env_file:
+      - ./neo4j/.env.neo4j
+    networks:
+      - app-network
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "wget --spider --quiet http://localhost:7474 || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s # Neo4j can take a while to start
+
+volumes:
+  neo4j_data:
+  neo4j_logs:
+
+networks:
+  app-network:
+    driver: bridge

--- a/neo4j/.env.neo4j.example
+++ b/neo4j/.env.neo4j.example
@@ -1,0 +1,19 @@
+# Neo4j Service Configuration
+
+# Neo4j Authentication
+# This sets the initial password for the 'neo4j' user.
+# IMPORTANT: Change 'your_strong_neo4j_password' to a secure password.
+# This password must match NEO4J_PASSWORD in the backend configuration.
+NEO4J_AUTH=neo4j/your_strong_neo4j_password
+
+# Accept Neo4j License Agreement (required for some versions/editions)
+NEO4J_ACCEPT_LICENSE_AGREEMENT=yes
+
+# Example of enabling APOC procedures (uncomment if needed)
+# NEO4J_dbms_security_procedures_unrestricted=apoc.*,gds.*
+
+# For Neo4j Aura, you would use different variables like:
+# NEO4J_URI=neo4j+s://xxxx.databases.neo4j.io
+# NEO4J_USERNAME=neo4j
+# NEO4J_PASSWORD=your_aura_password
+# (Ensure these are not mixed with local Docker deployment variables unless intended)

--- a/scripts/docker_monitor.sh
+++ b/scripts/docker_monitor.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+# Navigate to the directory where docker-compose.yml is located
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+PROJECT_ROOT="$( dirname "$SCRIPT_DIR" )"
+
+cd "$PROJECT_ROOT" || exit
+
+echo "=== Docker Services Monitor ==="
+echo "Timestamp: $(date)"
+echo ""
+
+# Check if Docker is running
+if ! docker info > /dev/null 2>&1; then
+  echo "❌ Docker does not seem to be running. Please start Docker and try again."
+  exit 1
+fi
+
+# Check if docker-compose.yml exists
+if [ ! -f docker-compose.yml ]; then
+    echo "❌ docker-compose.yml not found in the project root!"
+    exit 1
+fi
+
+echo "--- Services Status (docker-compose ps) ---"
+docker-compose ps
+echo ""
+
+echo "--- Container Resource Usage (docker stats - one snapshot) ---"
+# Show stats for containers managed by this docker-compose.yml
+# Get container names/IDs from docker-compose ps
+COMPOSE_PROJECT_NAME=$(basename "$PROJECT_ROOT") # Docker Compose typically names containers projectname_servicename_1
+# Attempt to get container IDs for services defined in the compose file
+CONTAINER_IDS=$(docker-compose ps -q 2>/dev/null)
+
+if [ -n "$CONTAINER_IDS" ]; then
+    docker stats --no-stream $CONTAINER_IDS
+else
+    echo "Could not retrieve container IDs. Skipping docker stats."
+    # Fallback or alternative if above fails consistently
+    # docker stats --no-stream $(docker ps --filter label=com.docker.compose.project="$COMPOSE_PROJECT_NAME" -q)
+fi
+echo ""
+
+echo "--- Health Checks (as defined in docker-compose.yml) ---"
+SERVICES=("backend" "frontend" "neo4j") # Services defined in docker-compose.yml
+
+for SERVICE_NAME in "${SERVICES[@]}"; do
+    # Construct the expected container name. Default is project_service_1
+    # For project names with special characters or very long names, this might need adjustment.
+    # A more robust way is to use docker-compose ps -q <service_name>
+    CONTAINER_ID=$(docker-compose ps -q "$SERVICE_NAME" 2>/dev/null)
+
+    if [ -z "$CONTAINER_ID" ]; then
+        echo "⚠️ Could not find container for service: $SERVICE_NAME. It might not be running or defined."
+        continue
+    fi
+
+    # Get the full container name using the ID, useful if multiple replicas exist (though not in this setup)
+    FULL_CONTAINER_NAME=$(docker inspect --format='{{.Name}}' "$CONTAINER_ID" | sed 's/^\///')
+
+
+    HEALTH_STATUS=$(docker inspect --format='{{json .State.Health}}' "$CONTAINER_ID" 2>/dev/null)
+
+    if [ -z "$HEALTH_STATUS" ] || [ "$HEALTH_STATUS" == "null" ]; then
+        echo "ጤ Health status not available or not configured for $FULL_CONTAINER_NAME ($SERVICE_NAME)."
+    else
+        STATUS=$(echo "$HEALTH_STATUS" | grep -o '"Status":"[^"]*"' | sed 's/"Status":"//;s/"//')
+        # LOG=$(echo "$HEALTH_STATUS" | jq -r '.Log[-1].Output' 2>/dev/null || echo "No log details") # Requires jq
+        # For simplicity without jq:
+        LOG_OUTPUT=$(docker inspect --format='{{range .State.Health.Log}}{{.Output}}{{end}}' "$CONTAINER_ID" | tail -n 1 | sed 's/\n//g; s/\r//g')
+
+
+        case "$STATUS" in
+          "healthy")
+            echo "✅ $FULL_CONTAINER_NAME ($SERVICE_NAME) is healthy."
+            ;;
+          "unhealthy")
+            echo "❌ $FULL_CONTAINER_NAME ($SERVICE_NAME) is unhealthy."
+            [ -n "$LOG_OUTPUT" ] && echo "   Last health log: $LOG_OUTPUT"
+            ;;
+          "starting")
+            echo "⏳ $FULL_CONTAINER_NAME ($SERVICE_NAME) is starting..."
+            ;;
+          *)
+            echo "❓ Unknown health status for $FULL_CONTAINER_NAME ($SERVICE_NAME): $STATUS"
+            [ -n "$LOG_OUTPUT" ] && echo "   Last health log: $LOG_OUTPUT"
+            ;;
+        esac
+    fi
+done
+echo ""
+
+echo "--- Log Tailing ---"
+echo "To view live logs for all services, run: docker-compose logs -f"
+echo "To view logs for a specific service (e.g., backend), run: docker-compose logs -f backend"
+echo ""
+
+echo "=== Monitoring Script Finished ==="

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Navigate to the directory where docker-compose.yml is located (project root)
+# This assumes the script is run from the project root or the script navigates correctly.
+# If this script is in a 'scripts' subdirectory, it needs to go up one level.
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+PROJECT_ROOT="$( dirname "$SCRIPT_DIR" )"
+
+cd "$PROJECT_ROOT" || exit
+
+# Check if Docker is running
+if ! docker info > /dev/null 2>&1; then
+  echo "Docker does not seem to be running, please start Docker and try again."
+  exit 1
+fi
+
+# Check if docker-compose.yml exists
+if [ ! -f docker-compose.yml ]; then
+    echo "docker-compose.yml not found in the project root!"
+    exit 1
+fi
+
+echo "Building and starting all services..."
+
+# Pull latest images for base services like neo4j (optional, but good practice)
+docker-compose pull neo4j
+
+# Build and start all services in detached mode
+docker-compose up --build -d
+
+if [ $? -eq 0 ]; then
+  echo "All services started successfully."
+  echo "Backend should be accessible on http://localhost:8000 (or your configured port)"
+  echo "Frontend should be accessible on http://localhost (or your configured port)"
+  echo "Neo4j Browser should be accessible on http://localhost:7474"
+  echo "To see logs, run: docker-compose logs -f"
+  echo "To stop services, run: docker-compose down"
+else
+  echo "There was an error starting the services. Check the output above."
+  echo "You can try running 'docker-compose up --build' without '-d' to see live logs."
+fi


### PR DESCRIPTION
This commit introduces a comprehensive Docker-based deployment and monitoring solution for the knowledge graph platform.

Key components added:
- Dockerfile for the FastAPI backend (`backend/Dockerfile`)
- Dockerfile for the SvelteKit frontend (`bridge-knowledge-platform/frontend/Dockerfile`) including Nginx for serving.
- `docker-compose.yml` to orchestrate backend, frontend, and Neo4j services.
  - Includes health checks, restart policies, volume persistence for Neo4j, and network configuration.
- Environment variable management using `.env` files:
  - `backend/.env.backend.example`
  - `neo4j/.env.neo4j.example`
  - `docker-compose.yml` updated to use `env_file`.
- Scripts:
  - `scripts/start.sh`: One-click script to build and start all services.
  - `scripts/docker_monitor.sh`: Script to monitor container status, resource usage, and health checks.
- Configuration:
  - Added `bridge-knowledge-platform/frontend/nginx.conf` for SvelteKit SPA routing.
  - Updated `.gitignore` to exclude Docker `.env` files and local Neo4j data/log folders.
  - Created `neo4j` directory for Neo4j related configurations.

The existing `monitor_system.sh` (application-level monitoring) and `setup.sh` (local development setup) are preserved and complemented by this Docker solution.

To use this solution:
1. Ensure Docker and Docker Compose are installed.
2. Create `backend/.env.backend` from the example and fill in `NEO4J_PASSWORD` and `DEEPSEEK_API_KEY`.
3. Create `neo4j/.env.neo4j` from the example and set the `NEO4J_AUTH` password (must match the one in `backend/.env.backend`).
4. Make scripts executable: `chmod +x scripts/start.sh scripts/docker_monitor.sh`.
5. Run `./scripts/start.sh` to build and launch the application.
6. Access:
   - Frontend: http://localhost
   - Backend API: http://localhost:8000
   - Neo4j Browser: http://localhost:7474